### PR TITLE
allow for mixed precision training

### DIFF
--- a/models/layers/group.py
+++ b/models/layers/group.py
@@ -76,6 +76,7 @@ class DilatedKNN(nn.Module):
 class GroupingOperation(Function):
 
     @staticmethod
+    @torch.cuda.custom_fwd(cast_inputs=torch.float32)
     def forward(ctx, features: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
         """
         :param ctx:


### PR DESCRIPTION
This is the only change needed to allow for mixed precision training (tested for pointnext_s and pointnet).
If unchanged, the this function breaks the mixed training since it expects floats but receives half precision.
The alternative would be to change the cuda kernel but memory saves are very noticeable already.

I am only using the model part of the framework currently but it works there.