### PR TITLE
Fix EMD kernel for pytorch 1.13

### DIFF
--- a/cpp/emd/cuda/emd_kernel.cu
+++ b/cpp/emd/cuda/emd_kernel.cu
@@ -16,7 +16,9 @@
 #define CHECK_CUDA(x) TORCH_CHECK(x.type().is_cuda(), #x " must be a CUDA tensor")
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 #define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
-#define CHECK_EQ(x, y) TORCH_CHECK_EQ(x, y)
+#ifndef CHECK_EQ
+	#define CHECK_EQ(x, y) TORCH_CHECK_EQ(x, y)
+#endif
 
 
 /********************************

--- a/cpp/emd/cuda/emd_kernel.cu
+++ b/cpp/emd/cuda/emd_kernel.cu
@@ -16,6 +16,7 @@
 #define CHECK_CUDA(x) TORCH_CHECK(x.type().is_cuda(), #x " must be a CUDA tensor")
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 #define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
+#define CHECK_EQ(x, y) TORCH_CHECK_EQ(x, y)
 
 
 /********************************


### PR DESCRIPTION
When pytorch 1.13 is used to build, the following error is seen:

```
cuda/emd_kernel.cu(178): error: identifier "CHECK_EQ" is undefined

cuda/emd_kernel.cu(265): error: identifier "CHECK_EQ" is undefined

cuda/emd_kernel.cu(382): error: identifier "CHECK_EQ" is undefined
```

Ref: https://github.com/CCInc/3d-ml/issues/34