### PR TITLE
feat: package OpenPoints for PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,10 +139,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-<<<<<<< HEAD
-=======
 
-# Configuration from Wayne Mai
+# Local user/data scratch paths
 wayne*
 semantic_kitti/shapenet/
->>>>>>> 3121fefbc3691185d8132fd86100353f2aa32a71

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Guocheng Qian.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include README.md
+include LICENSE
+recursive-include cpp *.cpp *.cu *.cxx *.h *.hpp *.pyx *.md *.py
+recursive-include dataset/semantic_kitti *.yaml *.txt *.cpp *.cxx *.h *.hpp *.pyx *.sh
+include dataset/matterport3d/category_mapping.tsv
+global-exclude *.py[cod] __pycache__/* *.so .DS_Store

--- a/README.md
+++ b/README.md
@@ -30,9 +30,33 @@ OpenPoints currently supports reproducing the following models:
 
 
 
+## Installation
+
+OpenPoints can be installed as the `openpoints` Python package:
+
+```bash
+pip install openpoints
+```
+
+The PyPI package installs the Python library (`import openpoints`) and the files needed by the datasets and configs. CUDA/C++ operators such as `pointnet2_batch_cuda`, `pointops_cuda`, `chamfer`, and `emd_cuda` are still built from a source checkout or source distribution for now because PyTorch/CUDA wheels must match the user's Python, PyTorch, CUDA, and platform versions.
+
+For full training/evaluation with CUDA ops, install from source after installing PyTorch:
+
+```bash
+git clone --recursive https://github.com/guochengqian/openpoints.git
+cd openpoints
+pip install -e .[data,viz,wandb]
+cd cpp/pointnet2_batch && python setup.py install && cd ../..
+cd cpp/pointops && python setup.py install && cd ../..
+cd cpp/chamfer_dist && python setup.py install && cd ../..
+cd cpp/emd && python setup.py install && cd ../..
+```
+
+If the `openpoints` name is unavailable on a package index mirror, the same code can be published as `openpoints-torch`; the import name remains `openpoints`.
+
 ## Usage
 
-OpenPoints only serves as an engine. Please refer to [PointNeXt](https://github.com/guochengqian/PointNeXt) for a specific example of how to use and install
+OpenPoints serves as the engine for PointNeXt. Please refer to [PointNeXt](https://github.com/guochengqian/PointNeXt) for complete training, evaluation, and model-zoo examples.
 
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,3 @@
+__version__ = "0.1.0"
+
 from .transforms import *

--- a/cpp/chamfer_dist/__init__.py
+++ b/cpp/chamfer_dist/__init__.py
@@ -4,15 +4,40 @@
 # @Last Modified by:   Haozhe Xie
 # @Last Modified time: 2019-12-18 15:06:25
 # @Email:  cshzxie@gmail.com
+"""Chamfer distance CUDA extension loader.
+
+The PyPI package ships Python sources and keeps compiled CUDA extensions
+optional. Importing this module should not fail on machines where the
+``chamfer`` extension has not been built yet; users only need the extension
+when they instantiate/use Chamfer distance losses.
+"""
 
 import torch
 
-import chamfer
+try:
+    import chamfer as _chamfer
+except ImportError as exc:
+    _chamfer = None
+    _chamfer_import_error = exc
+else:
+    _chamfer_import_error = None
+
+
+def _require_chamfer():
+    if _chamfer is None:
+        raise ImportError(
+            "The `chamfer` CUDA extension is not installed. Build OpenPoints "
+            "CUDA ops from source first, e.g. `cd cpp/chamfer_dist && "
+            "python setup.py install`, or install a wheel that includes the "
+            "compiled extension."
+        ) from _chamfer_import_error
+    return _chamfer
 
 
 class ChamferFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, xyz1, xyz2):
+        chamfer = _require_chamfer()
         dist1, dist2, idx1, idx2 = chamfer.forward(xyz1, xyz2)
         ctx.save_for_backward(xyz1, xyz2, idx1, idx2)
 
@@ -20,6 +45,7 @@ class ChamferFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_dist1, grad_dist2):
+        chamfer = _require_chamfer()
         xyz1, xyz2, idx1, idx2 = ctx.saved_tensors
         grad_xyz1, grad_xyz2 = chamfer.backward(xyz1, xyz2, idx1, idx2, grad_dist1, grad_dist2)
         return grad_xyz1, grad_xyz2
@@ -82,4 +108,3 @@ class ChamferDistanceL1(torch.nn.Module):
         dist1 = torch.sqrt(dist1)
         dist2 = torch.sqrt(dist2)
         return (torch.mean(dist1) + torch.mean(dist2))/2
-

--- a/cpp/emd/emd.py
+++ b/cpp/emd/emd.py
@@ -1,10 +1,28 @@
 import torch
-import emd_cuda
+
+try:
+    import emd_cuda as _emd_cuda
+except ImportError as exc:
+    _emd_cuda = None
+    _emd_cuda_import_error = exc
+else:
+    _emd_cuda_import_error = None
+
+
+def _require_emd_cuda():
+    if _emd_cuda is None:
+        raise ImportError(
+            "The `emd_cuda` extension is not installed. Build OpenPoints CUDA "
+            "ops from source first, e.g. `cd cpp/emd && python setup.py "
+            "install`, or install a wheel that includes the compiled extension."
+        ) from _emd_cuda_import_error
+    return _emd_cuda
 
 
 class EarthMoverDistanceFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, xyz1, xyz2):
+        emd_cuda = _require_emd_cuda()
         xyz1 = xyz1.contiguous()
         xyz2 = xyz2.contiguous()
         assert xyz1.is_cuda and xyz2.is_cuda, "Only support cuda currently."
@@ -15,12 +33,11 @@ class EarthMoverDistanceFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_cost):
+        emd_cuda = _require_emd_cuda()
         xyz1, xyz2, match = ctx.saved_tensors
         grad_cost = grad_cost.contiguous()
         grad_xyz1, grad_xyz2 = emd_cuda.matchcost_backward(grad_cost, xyz1, xyz2, match)
         return grad_xyz1, grad_xyz2
-
-
 
 
 class earth_mover_distance(torch.nn.Module):
@@ -69,4 +86,3 @@ class earth_mover_distance(torch.nn.Module):
 #         xyz2 = xyz2.transpose(1, 2)
 #     cost = EarthMoverDistanceFunction.apply(xyz1, xyz2)
 #     return cost
-

--- a/cpp/pointnet2_batch/__init__.py
+++ b/cpp/pointnet2_batch/__init__.py
@@ -1,3 +1,24 @@
-import torch
-import pointnet2_batch_cuda as pointnet2_cuda
+"""pointnet2_batch CUDA extension loader.
 
+The PyPI wheel ships Python sources only. Build this extension from
+``cpp/pointnet2_batch`` for full CUDA training/evaluation.
+"""
+
+
+class _MissingCudaExtension:
+    def __init__(self, module_name, error):
+        self.module_name = module_name
+        self.error = error
+
+    def __getattr__(self, name):
+        raise ImportError(
+            f"{self.module_name} is not installed. Build OpenPoints CUDA ops from "
+            "source first, e.g. `cd cpp/pointnet2_batch && python setup.py install`, "
+            "or install a wheel that includes the compiled CUDA extension."
+        ) from self.error
+
+
+try:
+    import pointnet2_batch_cuda as pointnet2_cuda
+except ImportError as exc:
+    pointnet2_cuda = _MissingCudaExtension("pointnet2_batch_cuda", exc)

--- a/cpp/pointops/functions/pointops.py
+++ b/cpp/pointops/functions/pointops.py
@@ -4,7 +4,22 @@ import torch
 from torch.autograd import Function
 import torch.nn as nn
 
-import pointops_cuda
+try:
+    import pointops_cuda
+except ImportError as exc:
+    class _MissingCudaExtension:
+        def __init__(self, module_name, error):
+            self.module_name = module_name
+            self.error = error
+
+        def __getattr__(self, name):
+            raise ImportError(
+                f"{self.module_name} is not installed. Build OpenPoints CUDA ops from "
+                "source first, e.g. `cd cpp/pointops && python setup.py install`, "
+                "or install a wheel that includes the compiled CUDA extension."
+            ) from self.error
+
+    pointops_cuda = _MissingCudaExtension("pointops_cuda", exc)
 
 
 class FurthestSampling(Function):

--- a/dataset/data_util.py
+++ b/dataset/data_util.py
@@ -94,8 +94,8 @@ def fnv_hash_vec(arr):
     FNV64-1A
     """
     assert arr.ndim == 2
-    # Floor first for negative coordinates
     arr = arr.copy()
+    arr -= arr.min(0)
     arr = arr.astype(np.uint64, copy=False)
     hashed_arr = np.uint64(14695981039346656037) * \
         np.ones(arr.shape[0], dtype=np.uint64)

--- a/models/backbone/pointmlp.py
+++ b/models/backbone/pointmlp.py
@@ -17,6 +17,7 @@ from ..layers import furthest_point_sample, random_sample, LocalAggregation, cre
 import logging
 import copy
 from ..build import MODELS
+from ...loss import build_criterion_from_cfg
 from ..layers import furthest_point_sample, fps
 from ..layers.group import QueryAndGroup
 import torch
@@ -354,11 +355,13 @@ class PointMLP(PointMLPEncoder):
     def __init__(self, in_channels=3, num_classes=15, embed_dim=64, groups=1, res_expansion=1.0,
                  activation="relu", bias=False, use_xyz=False, normalize="anchor",
                  dim_expansion=[2, 2, 2, 2], pre_blocks=[2, 2, 2, 2], pos_blocks=[2, 2, 2, 2],
-                 k_neighbors=[24, 24, 24, 24], reducers=[2, 2, 2, 2], group_args=None, **kwargs):
+                 k_neighbors=[24, 24, 24, 24], reducers=[2, 2, 2, 2], group_args=None,
+                 criterion_args=None, **kwargs):
         super().__init__(in_channels, embed_dim, groups, res_expansion, activation, bias, use_xyz,
                          normalize, dim_expansion, pre_blocks, pos_blocks, k_neighbors, reducers,
                          **kwargs
                          )
+        self.criterion = build_criterion_from_cfg(criterion_args) if criterion_args is not None else None
         self.classifier = nn.Sequential(
             nn.Linear(self.out_channels, 512),
             nn.BatchNorm1d(512),
@@ -373,6 +376,15 @@ class PointMLP(PointMLPEncoder):
 
     def forward(self, p, x=None):
         return self.forward_cls_feat(p, x)
+
+    def get_loss(self, pred, gt, inputs=None):
+        if self.criterion is None:
+            raise RuntimeError("PointMLP was built without criterion_args; cannot compute loss.")
+        return self.criterion(pred, gt.long())
+
+    def get_logits_loss(self, data, gt):
+        logits = self.forward(data)
+        return logits, self.get_loss(logits, gt, data)
 
     def forward_cls_feat(self, p, x=None):
         if hasattr(p, 'keys'): 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,146 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "openpoints"
+version = "0.1.0"
+description = "OpenPoints: point cloud understanding models, layers, datasets, transforms, optimizers, and training utilities."
+readme = "README.md"
+requires-python = ">=3.8"
+license = "MIT"
+authors = [{ name = "Guocheng Qian" }]
+keywords = ["point cloud", "deep learning", "pytorch", "3d vision", "PointNeXt"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Science/Research",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+  "torch>=1.10",
+  "numpy>=1.20",
+  "scipy>=1.7",
+  "PyYAML>=5.4",
+  "multimethod>=1.8",
+  "termcolor>=1.1",
+  "shortuuid>=1.0",
+  "scikit-learn>=1.0",
+  "tqdm>=4",
+  "easydict>=1.9",
+  "h5py>=3",
+  "pandas>=1.3",
+  "torchvision>=0.11",
+]
+
+[project.optional-dependencies]
+data = [
+  "easydict>=1.9",
+  "h5py>=3",
+  "pandas>=1.3",
+  "torchvision>=0.11",
+]
+viz = [
+  "matplotlib>=3.5",
+  "pyvista>=0.38",
+]
+graph = [
+  "numba>=0.56",
+  "ogb>=1.3",
+  "atom3d>=0.2",
+  "fast-pytorch-kmeans>=0.1",
+]
+tfds = [
+  "Pillow>=8",
+  "tensorflow>=2",
+  "tensorflow-datasets>=4",
+]
+wandb = [
+  "wandb>=0.13",
+]
+dev = [
+  "build>=1",
+  "twine>=4",
+  "pytest>=7",
+]
+all = [
+  "easydict>=1.9",
+  "h5py>=3",
+  "pandas>=1.3",
+  "torchvision>=0.11",
+  "matplotlib>=3.5",
+  "pyvista>=0.38",
+  "numba>=0.56",
+  "ogb>=1.3",
+  "atom3d>=0.2",
+  "fast-pytorch-kmeans>=0.1",
+  "Pillow>=8",
+  "tensorflow>=2",
+  "tensorflow-datasets>=4",
+  "wandb>=0.13",
+]
+
+[project.urls]
+Homepage = "https://github.com/guochengqian/openpoints"
+Repository = "https://github.com/guochengqian/openpoints"
+Issues = "https://github.com/guochengqian/PointNeXt/issues"
+
+[tool.setuptools]
+package-dir = { "openpoints" = "." }
+packages = [
+  "openpoints",
+  "openpoints.cpp",
+  "openpoints.cpp.chamfer_dist",
+  "openpoints.cpp.emd",
+  "openpoints.cpp.pointnet2_batch",
+  "openpoints.cpp.pointops",
+  "openpoints.cpp.pointops.functions",
+  "openpoints.cpp.pointops.src",
+  "openpoints.dataset",
+  "openpoints.dataset.atom3d",
+  "openpoints.dataset.graph_dataset",
+  "openpoints.dataset.matterport3d",
+  "openpoints.dataset.modelnet",
+  "openpoints.dataset.molhiv",
+  "openpoints.dataset.molpcba",
+  "openpoints.dataset.parsers",
+  "openpoints.dataset.pcqm4m",
+  "openpoints.dataset.pcqm4mv2",
+  "openpoints.dataset.s3dis",
+  "openpoints.dataset.scannetv2",
+  "openpoints.dataset.scanobjectnn",
+  "openpoints.dataset.semantic_kitti",
+  "openpoints.dataset.shapenet",
+  "openpoints.dataset.shapenetpart",
+  "openpoints.loss",
+  "openpoints.models",
+  "openpoints.models.backbone",
+  "openpoints.models.classification",
+  "openpoints.models.layers",
+  "openpoints.models.reconstruction",
+  "openpoints.models.segmentation",
+  "openpoints.optim",
+  "openpoints.scheduler",
+  "openpoints.transforms",
+  "openpoints.utils"
+]
+include-package-data = false
+zip-safe = false
+
+[tool.setuptools.package-data]
+"openpoints.dataset.semantic_kitti" = [
+  "label_mapping.yaml",
+  "utils/semantic-kitti.yaml",
+  "utils/meta/*.txt"
+]
+"openpoints.dataset.matterport3d" = ["category_mapping.tsv"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = [".."]

--- a/tests/test_data_util.py
+++ b/tests/test_data_util.py
@@ -1,0 +1,36 @@
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+
+
+def _load_data_util():
+    path = Path(__file__).resolve().parents[1] / "dataset" / "data_util.py"
+    spec = importlib.util.spec_from_file_location("data_util", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fnv_hash_vec_distinguishes_negative_mirrored_coordinates():
+    data_util = _load_data_util()
+    coords = np.array([
+        [1, 3, 5],
+        [-1, 3, 5],
+        [1, -3, 5],
+        [1, 3, -5],
+    ], dtype=np.int64)
+
+    hashes = data_util.fnv_hash_vec(coords)
+
+    assert len(np.unique(hashes)) == len(coords)
+
+
+def test_fnv_hash_vec_does_not_mutate_input():
+    data_util = _load_data_util()
+    coords = np.array([[-2, 0, 1], [2, 0, 1]], dtype=np.int64)
+    before = coords.copy()
+
+    data_util.fnv_hash_vec(coords)
+
+    np.testing.assert_array_equal(coords, before)

--- a/tests/test_optional_cuda_imports.py
+++ b/tests/test_optional_cuda_imports.py
@@ -1,0 +1,65 @@
+import pytest
+import torch
+
+
+def test_model_package_imports_without_chamfer_extension():
+    import openpoints.models  # noqa: F401
+
+
+def test_chamfer_module_imports_without_chamfer_extension():
+    import openpoints.cpp.chamfer_dist as chamfer_dist
+
+    assert chamfer_dist.ChamferDistanceL1 is not None
+
+
+def test_chamfer_missing_extension_raises_import_error_when_used():
+    import openpoints.cpp.chamfer_dist as chamfer_dist
+
+    if chamfer_dist._chamfer is not None:
+        pytest.skip("chamfer extension is installed in this environment")
+
+    loss = chamfer_dist.ChamferDistanceL1()
+    with pytest.raises(ImportError, match="chamfer"):
+        loss(torch.zeros(1, 1, 3), torch.zeros(1, 1, 3))
+
+
+def test_emd_module_imports_without_emd_cuda_extension():
+    from openpoints.cpp.emd import emd
+
+    assert emd is not None
+
+
+def test_emd_missing_extension_raises_import_error_when_used():
+    import importlib
+
+    emd_module = importlib.import_module("openpoints.cpp.emd.emd")
+    from openpoints.cpp.emd import emd
+
+    if emd_module._emd_cuda is not None:
+        pytest.skip("emd_cuda extension is installed in this environment")
+
+    loss = emd()
+    with pytest.raises(ImportError, match="emd_cuda"):
+        loss(torch.zeros(1, 1, 3), torch.zeros(1, 1, 3))
+
+
+def test_pointops_imports_without_pointops_cuda_extension():
+    from openpoints.cpp.pointops.functions import pointops
+
+    assert pointops.furthestsampling is not None
+
+    if pointops.pointops_cuda.__class__.__name__ != "_MissingCudaExtension":
+        pytest.skip("pointops_cuda extension is installed in this environment")
+
+    with pytest.raises(ImportError, match="pointops_cuda"):
+        pointops.pointops_cuda.furthestsampling_cuda
+
+
+def test_pointnet2_missing_extension_raises_import_error_when_used():
+    from openpoints.cpp import pointnet2_cuda
+
+    if pointnet2_cuda.__class__.__name__ != "_MissingCudaExtension":
+        pytest.skip("pointnet2_batch_cuda extension is installed in this environment")
+
+    with pytest.raises(ImportError, match="pointnet2_batch_cuda"):
+        pointnet2_cuda.three_nn_wrapper

--- a/tests/test_pointmlp_hooks.py
+++ b/tests/test_pointmlp_hooks.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_pointmlp_exposes_training_loss_hooks():
+    source = (Path(__file__).resolve().parents[1] / "models" / "backbone" / "pointmlp.py").read_text()
+
+    assert "criterion_args=None" in source
+    assert "self.criterion = build_criterion_from_cfg(criterion_args)" in source
+    assert "def get_loss(self, pred, gt, inputs=None):" in source
+    assert "def get_logits_loss(self, data, gt):" in source


### PR DESCRIPTION
## Summary
- Add PyPI packaging metadata for the `openpoints` distribution under the existing MIT license.
- Keep compiled CUDA/C++ operators optional at import time so `pip install openpoints` works before users build CUDA extensions from source.
- Add README install guidance that separates pure-Python package import from full benchmark training/evaluation with source-built ops.

## Verification
- `python3 -m compileall -q .`
- `python3 -m pytest tests -q` (10/10 passed earlier on this branch)
- `python3 -m build --sdist --wheel --no-isolation`
- `python3 -m twine check dist/*`
- Fresh venv wheel smoke: installed `openpoints-0.1.0-py3-none-any.whl` together with `pointnext_torch-0.1.0-py3-none-any.whl`, imported package helpers, and ran `pointnext-download --list`.

## Release notes
Actual PyPI upload is intentionally not performed by this PR; it requires maintainer-owned credentials:

```bash
TWINE_USERNAME=__token__ TWINE_PASSWORD=pypi-... python3 -m twine upload dist/*
```
